### PR TITLE
Option for using default X server

### DIFF
--- a/src/stimpack/experiment/client.py
+++ b/src/stimpack/experiment/client.py
@@ -30,15 +30,10 @@ class BaseClient():
             if isinstance(self.trigger_device, daq.DAQonServer):
                 self.trigger_device.set_manager(self.manager)
         else:
-            disp_env = os.environ['DISPLAY']
             if 'disp_server_id' in self.server_options:
                 disp_server, disp_id = self.server_options['disp_server_id']
             else:
-                try:
-                    disp_server, disp_id = (int(x) if x.isnumeric() else 0 for x in disp_env.split(':'))
-                except:
-                    disp_server, disp_id = 0, 0
-            print (f"Using display server {disp_server} and id {disp_id}")
+                disp_server, disp_id = -1, -1
             
             aux_screen = Screen(server_number=disp_server, id=disp_id, fullscreen=False, vsync=True, square_size=(0.25, 0.25))
             # other_stim_module_paths=[] stops StimServer from importing user stimuli modules from a txt file

--- a/src/stimpack/visual_stim/screen.py
+++ b/src/stimpack/visual_stim/screen.py
@@ -82,10 +82,10 @@ class Screen:
         """
         if subscreens is None:
             subscreens = [ SubScreen(pa=pa, pb=pb, pc=pc) ]
-        if server_number is None:
-            server_number = 0
+        if server_number is None: # server_number and id of -1 means use default X server. See stim_server.launch_screen
+            server_number = -1
         if id is None:
-            id = 0
+            id = -1
         if fullscreen is None:
             fullscreen = True
         if vsync is None:

--- a/src/stimpack/visual_stim/stim_server.py
+++ b/src/stimpack/visual_stim/stim_server.py
@@ -22,7 +22,14 @@ def launch_screen(screen, **kwargs):
     # set the arguments as necessary
     new_env_vars = {}
     if platform.system() in ['Linux', 'Darwin']:
-        new_env_vars['DISPLAY'] = ':{}.{}'.format(screen.server_number, screen.id)
+        if screen.server_number == -1 and screen.id == -1:
+            print('Initializing screen with default X display server.')
+        elif screen.server_number == -1:
+            new_env_vars['DISPLAY'] = ':{}'.format(screen.id)
+        elif screen.id == -1:
+            new_env_vars['DISPLAY'] = ':{}.0'.format(screen.server_number)
+        else:
+            new_env_vars['DISPLAY'] = ':{}.{}'.format(screen.server_number, screen.id)
     # launch the server and return the resulting client
     return launch_server(stimpack.visual_stim.framework, screen=screen.serialize(), new_env_vars=new_env_vars, **kwargs)
 


### PR DESCRIPTION
Instead of trying to infer what the default X server is by looking for DISPLAY environment variable, just have an option to not set the DISPLAY variable in stim_server.launch_screen such that the user's OS can determine where to send the visual_stim screen window. 

Tested on Linux. Should be irrelevant on Mac. Not tested on Window.