### PR TITLE
Update to PyQT6

### DIFF
--- a/examples/visual_stim/moving_patch.py
+++ b/examples/visual_stim/moving_patch.py
@@ -26,7 +26,7 @@ def main():
     manager.load_stim(name='MovingSpot', radius=5, sphere_radius=1, color=color_trajectory, theta=theta_trajectory, phi=0, hold=True)
 
 
-    sleep(1)
+    sleep(2)
 
     manager.start_stim()
     sleep(4)

--- a/examples/visual_stim/spot.py
+++ b/examples/visual_stim/spot.py
@@ -1,4 +1,5 @@
-from PyQt5 import QtOpenGL, QtWidgets, QtCore
+from PyQt5 import QtWidgets, QtCore
+from PyQt5.QtWidgets import QOpenGLWidget
 
 import sys
 import signal
@@ -78,7 +79,7 @@ class SpotProgram:
         # render to screen
         self.vao.render(mode=moderngl.TRIANGLE_STRIP)
 
-class SpotDisplay(QtOpenGL.QGLWidget):
+class SpotDisplay(QtWidgets.QOpenGLWidget):
     """
     Class that controls the stimulus display on one screen.  It contains the pyglet window object for that screen,
     and also controls rendering of the stimulus, toggling corner square, and/or debug information.
@@ -152,11 +153,11 @@ class SpotDisplay(QtOpenGL.QGLWidget):
         """
 
         # create format with default settings
-        format = QtOpenGL.QGLFormat()
+        format = QOpenGLWidget.defaultFormat()
 
         # use OpenGL 3.3
         format.setVersion(3, 3)
-        format.setProfile(QtOpenGL.QGLFormat.CoreProfile)
+        format.setProfile(QOpenGLWidget.CoreProfile)
 
         # use VSYNC
         if vsync:

--- a/examples/visual_stim/spot.py
+++ b/examples/visual_stim/spot.py
@@ -1,5 +1,5 @@
-from PyQt5 import QtWidgets, QtCore
-from PyQt5.QtWidgets import QOpenGLWidget
+from PyQt6 import QtWidgets, QtCore
+from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 
 import sys
 import signal

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,11 @@ setup(
         'matplotlib',
         
         'platformdirs',
-        'PyQT5',
+        'PyQT6',
         'h5py',
         'pyYaml',
         
         'moderngl',
-        'qimage2ndarray',
         'scikit-image',
     ],
     entry_points={

--- a/src/stimpack/experiment/client.py
+++ b/src/stimpack/experiment/client.py
@@ -4,7 +4,7 @@
 from time import sleep
 import os
 import posixpath
-from PyQt5.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication
 
 from stimpack.rpc.transceiver import MySocketClient
 from stimpack.visual_stim.stim_server import launch_stim_server

--- a/src/stimpack/experiment/gui.py
+++ b/src/stimpack/experiment/gui.py
@@ -10,14 +10,14 @@ import os
 import sys
 import time
 from enum import Enum
-from PyQt5.QtWidgets import (QPushButton, QWidget, QLabel, QTextEdit, QGridLayout, QApplication,
+from PyQt6.QtWidgets import (QPushButton, QWidget, QLabel, QTextEdit, QGridLayout, QApplication,
                              QComboBox, QLineEdit, QFormLayout, QDialog, QFileDialog, QInputDialog,
                              QMessageBox, QCheckBox, QSpinBox, QTabWidget, QVBoxLayout, QFrame,
                              QTableWidget, QTableWidgetItem, QTreeWidget, QTreeWidgetItem,
                              QScrollArea, QSizePolicy)
-import PyQt5.QtCore as QtCore
-from PyQt5.QtCore import QThread, QTimer
-import PyQt5.QtGui as QtGui
+import PyQt6.QtCore as QtCore
+from PyQt6.QtCore import QThread, QTimer, Qt
+import PyQt6.QtGui as QtGui
 
 from stimpack.experiment.util import config_tools, h5io
 from stimpack.experiment import protocol, data, client
@@ -100,12 +100,12 @@ class ExperimentGUI(QWidget):
         self.protocol_box = QWidget()
         self.parameter_grid = QGridLayout()
         self.parameter_grid.setSpacing(10)
-        self.protocol_box.setSizePolicy(QSizePolicy(QSizePolicy.MinimumExpanding,
-                                            QSizePolicy.MinimumExpanding))
+        self.protocol_box.setSizePolicy(QSizePolicy(QSizePolicy.Policy.MinimumExpanding,
+                                            QSizePolicy.Policy.MinimumExpanding))
         
         self.protocol_selector_box = QWidget()
-        self.protocol_selector_box.setSizePolicy(QSizePolicy(QSizePolicy.MinimumExpanding,
-                                                            QSizePolicy.Fixed))
+        self.protocol_selector_box.setSizePolicy(QSizePolicy(QSizePolicy.Policy.MinimumExpanding,
+                                                            QSizePolicy.Policy.Fixed))
         self.protocol_selector_grid = QGridLayout()
 
         self.protocol_params_scroll_box = QScrollArea()
@@ -113,8 +113,8 @@ class ExperimentGUI(QWidget):
         self.protocol_params_scroll_box.setWidgetResizable(True)
 
         self.protocol_control_box = QWidget()
-        self.protocol_control_box.setSizePolicy(QSizePolicy(QSizePolicy.MinimumExpanding,
-                                                            QSizePolicy.Fixed))
+        self.protocol_control_box.setSizePolicy(QSizePolicy(QSizePolicy.Policy.MinimumExpanding,
+                                                            QSizePolicy.Policy.Fixed))
         self.protocol_control_grid = QGridLayout()
 
         self.protocol_tab = QWidget()
@@ -125,13 +125,13 @@ class ExperimentGUI(QWidget):
 
         self.data_tab = QWidget()
         self.data_form = QFormLayout()
-        self.data_form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
-        self.data_form.setLabelAlignment(QtCore.Qt.AlignCenter)
+        self.data_form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+        self.data_form.setLabelAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.file_tab = QWidget()
         self.file_form = QFormLayout()
-        self.file_form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
-        self.file_form.setLabelAlignment(QtCore.Qt.AlignCenter)
+        self.file_form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+        self.file_form.setLabelAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.tabs.addTab(self.protocol_tab, "Main")
         self.tabs.addTab(self.data_tab, "Animal")
@@ -146,7 +146,7 @@ class ExperimentGUI(QWidget):
         for sub_class in self.available_protocols:
             protocol_selection_combo_box.addItem(sub_class.__name__)
         protocol_label = QLabel('Protocol:')
-        protocol_selection_combo_box.activated[str].connect(self.on_selected_protocol_ID)
+        protocol_selection_combo_box.textActivated.connect(self.on_selected_protocol_ID)
         self.protocol_selector_grid.addWidget(protocol_label, 1, 0)
         self.protocol_selector_grid.addWidget(protocol_selection_combo_box, 1, 1, 1, 1)
 
@@ -236,12 +236,12 @@ class ExperimentGUI(QWidget):
         # # Animal info:
         new_label = QLabel('Load existing animal')
         self.existing_animal_input = QComboBox()
-        self.existing_animal_input.activated[int].connect(self.on_selected_existing_animal)
+        self.existing_animal_input.activated.connect(self.on_selected_existing_animal)
         self.data_form.addRow(new_label, self.existing_animal_input)
         self.update_existing_animal_input()
 
         new_label = QLabel('Current Animal info:')
-        new_label.setAlignment(QtCore.Qt.AlignCenter)
+        new_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.data_form.addRow(new_label)
 
         # Only built-ins are "animal_id," "age" and "notes"
@@ -312,13 +312,13 @@ class ExperimentGUI(QWidget):
         item.setFont(font)
         item.setBackground(QtGui.QColor(121, 121, 121))
         brush = QtGui.QBrush(QtGui.QColor(91, 91, 91))
-        brush.setStyle(QtCore.Qt.SolidPattern)
+        brush.setStyle(Qt.BrushStyle.SolidPattern)
         item.setForeground(brush)
         self.table_attributes.setHorizontalHeaderItem(0, item)
         item = QTableWidgetItem()
         item.setBackground(QtGui.QColor(123, 123, 123))
         brush = QtGui.QBrush(QtGui.QColor(91, 91, 91))
-        brush.setStyle(QtCore.Qt.SolidPattern)
+        brush.setStyle(Qt.BrushStyle.SolidPattern)
         item.setForeground(brush)
         self.table_attributes.setHorizontalHeaderItem(1, item)
         self.table_attributes.horizontalHeader().setCascadingSectionResizes(True)
@@ -562,7 +562,7 @@ class ExperimentGUI(QWidget):
         self.parameter_preset_comboBox.addItem("Default")
         for name in self.protocol_object.parameter_presets.keys():
             self.parameter_preset_comboBox.addItem(name)
-        self.parameter_preset_comboBox.activated[str].connect(self.on_selected_parameter_preset)
+        self.parameter_preset_comboBox.textActivated.connect(self.on_selected_parameter_preset)
         self.protocol_selector_grid.addWidget(self.parameter_preset_comboBox, 2, 1, 1, 1)
 
     def on_selected_parameter_preset(self, text):

--- a/src/stimpack/util.py
+++ b/src/stimpack/util.py
@@ -1,6 +1,6 @@
 import inspect
 import os
-from PyQt5.QtWidgets import QMessageBox
+from PyQt6.QtWidgets import QMessageBox
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 ICON_PATH = os.path.join(ROOT_DIR, '_assets', 'icon.png')

--- a/src/stimpack/visual_stim/framework.py
+++ b/src/stimpack/visual_stim/framework.py
@@ -136,7 +136,7 @@ class StimDisplay(QOpenGLWidget):
         # Get viewport for corner square
         self.square_program.set_viewport(display_width, display_height)
 
-        self.ctx.clear(0, 0, 0, 1) # clear the previous frame across the whole display
+        # self.ctx.clear(0, 0, 0, 1) # clear the previous frame across the whole display
         # draw the stimulus
         if self.stim_list:
             if self.pre_render:
@@ -455,12 +455,10 @@ def make_qt_format(vsync):
         format.setSwapInterval(0)
 
     # TODO: determine what these lines do and whether they are necessary
-    # format.setSampleBuffers(True)
     format.setSamples(24)
     format.setDepthBufferSize(24)
 
     # needed to enable transparency
-    # format.setAlpha(True)
     format.setAlphaBufferSize(24)
 
     return format
@@ -476,9 +474,9 @@ def main():
     # launch the server
     server = MySocketServer(host=kwargs['host'], port=kwargs['port'], threaded=True, auto_stop=True, name=screen.name)
 
-    QtGui.QSurfaceFormat.setDefaultFormat(make_qt_format(vsync=screen.vsync))
 
     # launch application
+    QtGui.QSurfaceFormat.setDefaultFormat(make_qt_format(vsync=screen.vsync))
     app = QtWidgets.QApplication([])
     app.setWindowIcon(QtGui.QIcon(ICON_PATH))
     app.setApplicationName('Stimpack visual_stim screen: {screen.name}')

--- a/src/stimpack/visual_stim/framework.py
+++ b/src/stimpack/visual_stim/framework.py
@@ -44,18 +44,6 @@ class StimDisplay(QOpenGLWidget):
         self.setWindowTitle(f'Stimpack visual_stim screen: {screen.name}')
         self.setWindowIcon(QtGui.QIcon(ICON_PATH))
 
-        # configure window to reside on a specific screen
-        # re: https://stackoverflow.com/questions/6854947/how-to-display-a-window-on-a-secondary-display-in-pyqt
-        # if screen.fullscreen:
-        #     # qscreens = QtGui.QGuiApplication.screens()
-        #     # widget = QtWidgets.QWidget()
-        #     # widget.setScreen()
-
-        #     desktop = QtWidgets.QDesktopWidget()
-        #     rectScreen = desktop.screenGeometry(screen.id)
-        #     self.move(rectScreen.left(), rectScreen.top())
-        #     self.resize(rectScreen.width(), rectScreen.height())
-
         # stimulus initialization
         self.stim_list = []
 

--- a/src/stimpack/visual_stim/framework.py
+++ b/src/stimpack/visual_stim/framework.py
@@ -46,11 +46,15 @@ class StimDisplay(QOpenGLWidget):
 
         # configure window to reside on a specific screen
         # re: https://stackoverflow.com/questions/6854947/how-to-display-a-window-on-a-secondary-display-in-pyqt
-        if screen.fullscreen:
-            desktop = QtWidgets.QDesktopWidget()
-            rectScreen = desktop.screenGeometry(screen.id)
-            self.move(rectScreen.left(), rectScreen.top())
-            self.resize(rectScreen.width(), rectScreen.height())
+        # if screen.fullscreen:
+        #     # qscreens = QtGui.QGuiApplication.screens()
+        #     # widget = QtWidgets.QWidget()
+        #     # widget.setScreen()
+
+        #     desktop = QtWidgets.QDesktopWidget()
+        #     rectScreen = desktop.screenGeometry(screen.id)
+        #     self.move(rectScreen.left(), rectScreen.top())
+        #     self.resize(rectScreen.width(), rectScreen.height())
 
         # stimulus initialization
         self.stim_list = []

--- a/src/stimpack/visual_stim/framework.py
+++ b/src/stimpack/visual_stim/framework.py
@@ -9,7 +9,8 @@ import numpy as np
 import pandas as pd
 import qimage2ndarray
 from skimage.transform import downscale_local_mean
-from PyQt5 import QtOpenGL, QtWidgets, QtGui
+from PyQt5 import QtWidgets, QtGui
+from PyQt5.QtWidgets import QOpenGLWidget
 
 from stimpack.util import get_all_subclasses, ICON_PATH
 
@@ -24,7 +25,7 @@ from stimpack.visual_stim.screen import Screen
 from stimpack.rpc.transceiver import MySocketServer
 from stimpack.rpc.util import get_kwargs
 
-class StimDisplay(QtOpenGL.QGLWidget):
+class StimDisplay(QOpenGLWidget):
     """
     Class that controls the stimulus display on one screen.  It contains the pyglet window object for that screen,
     and also controls rendering of the stimulus, toggling corner square, and/or debug information.
@@ -38,7 +39,8 @@ class StimDisplay(QtOpenGL.QGLWidget):
         be displayed.
         """
         # call super constructor
-        super().__init__(make_qt_format(vsync=screen.vsync))
+        super().__init__()
+        self.setFormat(make_qt_format(vsync=screen.vsync))
 
         self.setWindowTitle(f'Stimpack visual_stim screen: {screen.name}')
         self.setWindowIcon(QtGui.QIcon(ICON_PATH))
@@ -440,11 +442,11 @@ def make_qt_format(vsync):
     """
 
     # create format with default settings
-    format = QtOpenGL.QGLFormat()
+    format = QtGui.QSurfaceFormat()
 
     # use OpenGL 3.3
     format.setVersion(3, 3)
-    format.setProfile(QtOpenGL.QGLFormat.CoreProfile)
+    format.setProfile(QtGui.QSurfaceFormat.CoreProfile)
 
     # use VSYNC
     if vsync:
@@ -453,11 +455,13 @@ def make_qt_format(vsync):
         format.setSwapInterval(0)
 
     # TODO: determine what these lines do and whether they are necessary
-    format.setSampleBuffers(True)
+    # format.setSampleBuffers(True)
+    format.setSamples(24)
     format.setDepthBufferSize(24)
 
     # needed to enable transparency
-    format.setAlpha(True)
+    # format.setAlpha(True)
+    format.setAlphaBufferSize(24)
 
     return format
 
@@ -471,6 +475,8 @@ def main():
 
     # launch the server
     server = MySocketServer(host=kwargs['host'], port=kwargs['port'], threaded=True, auto_stop=True, name=screen.name)
+
+    QtGui.QSurfaceFormat.setDefaultFormat(make_qt_format(vsync=screen.vsync))
 
     # launch application
     app = QtWidgets.QApplication([])

--- a/src/stimpack/visual_stim/framework.py
+++ b/src/stimpack/visual_stim/framework.py
@@ -511,9 +511,7 @@ def main():
     # launch the server
     server = MySocketServer(host=kwargs['host'], port=kwargs['port'], threaded=True, auto_stop=True, name=screen.name)
 
-
     # launch application
-    QtGui.QSurfaceFormat.setDefaultFormat(make_qt_format(vsync=screen.vsync))
     app = QtWidgets.QApplication([])
     app.setWindowIcon(QtGui.QIcon(ICON_PATH))
     app.setApplicationName('Stimpack visual_stim screen: {screen.name}')

--- a/src/stimpack/visual_stim/framework.py
+++ b/src/stimpack/visual_stim/framework.py
@@ -483,7 +483,7 @@ def make_qt_format(vsync):
 
     # use OpenGL 3.3
     format.setVersion(3, 3)
-    format.setProfile(QtGui.QSurfaceFormat.OpenGLContextProfile(1))
+    format.setProfile(QtGui.QSurfaceFormat.OpenGLContextProfile.CoreProfile)
 
     # use VSYNC
     if vsync:

--- a/src/stimpack/visual_stim/framework.py
+++ b/src/stimpack/visual_stim/framework.py
@@ -7,10 +7,9 @@ from math import radians
 import moderngl
 import numpy as np
 import pandas as pd
-import qimage2ndarray
 from skimage.transform import downscale_local_mean
-from PyQt5 import QtWidgets, QtGui
-from PyQt5.QtWidgets import QOpenGLWidget
+from PyQt6 import QtWidgets, QtGui
+from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 
 from stimpack.util import get_all_subclasses, ICON_PATH
 
@@ -137,6 +136,7 @@ class StimDisplay(QOpenGLWidget):
         self.square_program.set_viewport(display_width, display_height)
 
         # self.ctx.clear(0, 0, 0, 1) # clear the previous frame across the whole display
+        # self.ctx.clear(red=self.idle_background, green=self.idle_background, blue=self.idle_background, alpha=1.0)
         # draw the stimulus
         if self.stim_list:
             if self.pre_render:
@@ -191,7 +191,7 @@ class StimDisplay(QOpenGLWidget):
 
             if self.append_stim_frames:
                 # grab frame buffer, convert to array, grab blue channel, append to list of stim_frames
-                self.stim_frames.append(qimage2ndarray.rgb_view(self.grabFrameBuffer())[:, :, 2])
+                self.stim_frames.append(util.qimage2ndarray(self.grabFrameBuffer())[:, :, 2])
                 self.current_time_index += 1
 
     ###########################################
@@ -446,7 +446,7 @@ def make_qt_format(vsync):
 
     # use OpenGL 3.3
     format.setVersion(3, 3)
-    format.setProfile(QtGui.QSurfaceFormat.CoreProfile)
+    format.setProfile(QtGui.QSurfaceFormat.OpenGLContextProfile(1))
 
     # use VSYNC
     if vsync:
@@ -528,7 +528,7 @@ def main():
     # Use Ctrl+C to exit.
     # ref: https://stackoverflow.com/questions/2300401/qapplication-how-to-shutdown-gracefully-on-ctrl-c
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 if __name__ == '__main__':
     main()

--- a/src/stimpack/visual_stim/util.py
+++ b/src/stimpack/visual_stim/util.py
@@ -33,6 +33,19 @@ def generate_lowercase_barcode(length=5, existing_barcodes=[]):
 def normalize(vec):
     return vec / np.linalg.norm(vec)
 
+def qimage2ndarray(qimage):
+    '''  Converts a QImage into an opencv MAT format  '''
+
+    qimage = qimage.convertToFormat(4)
+
+    width = qimage.width()
+    height = qimage.height()
+
+    ptr = qimage.bits()
+    ptr.setsize(qimage.byteCount())
+    arr = np.array(ptr).reshape(height, width, 4)  #  Copies the data
+    return arr
+
 # rotation matrix reference:
 # https://en.wikipedia.org/wiki/Rotation_matrix
 

--- a/tests/visual_stim/common.py
+++ b/tests/visual_stim/common.py
@@ -1,7 +1,8 @@
 import moderngl
 import numpy as np
 from PIL import Image
-from PyQt5 import QtOpenGL, QtWidgets
+from PyQt6 import QtWidgets, QtGui
+from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 
 
 class HeadlessDisplay:
@@ -36,14 +37,14 @@ class HeadlessDisplay:
         return Image.frombytes('RGB', self.fbo.size, self.fbo.read(), 'raw', 'RGB', 0, -1)
 
 
-class QtTestDisplay(QtOpenGL.QGLWidget):
+class QtTestDisplay(QOpenGLWidget):
     # adapted from https://github.com/moderngl/moderngl/blob/master/examples/old-examples/PyQt5/01_hello_world.py
     def __init__(self, width=512, height=512):
         # Set up OpenGL format
-        fmt = QtOpenGL.QGLFormat()
+        fmt = QtGui.QSurfaceFormat()
         fmt.setVersion(3, 3)
-        fmt.setProfile(QtOpenGL.QGLFormat.CoreProfile)
-        fmt.setSampleBuffers(True)
+        fmt.setProfile(QtGui.QSurfaceFormat.OpenGLContextProfile(1))
+        fmt.setSamples(24)
         super(QtTestDisplay, self).__init__(fmt, None)
 
         # Set the window size and position


### PR DESCRIPTION
- **Updated from PyQT5 to PyQT6**
- **Use QOpenGLWidget in place of QGLWidget**
- **Remove dependency on qimage2ndarray**
- **visual_stim.framework.idle_background is now a RGBA tuple**: visual_stim.framework.set_idle_background color argument can be monochrome, RGB, or RGBA.
- **Clear viewports for visual_stim more sparingly**: Clearing screen used to occur at every visual_stim.framework.paintGL call, and clearing subscreen viewports used to occur at every paintGL call while stim was not loaded or started. Now, clearing the whole screen only occurs at framework.initializeGL, and clearing viewports only occur through the clear_viewports_flag once at each load_stim call and once at each stop_stim call.

To check:
- [ ] Works on subscreen setup (e.g. 24HrFitness)
- [ ] Works on multiscreen setup (e.g. 40HrFitness / Bruker)