### PR TITLE
visual_stim module import through cfg labpack relative path

### DIFF
--- a/stimpack/experiment/client.py
+++ b/stimpack/experiment/client.py
@@ -87,7 +87,7 @@ class BaseClient():
         # # # Import user-defined stimpack.visual_stim stimuli modules on server screens # # #
         visual_stim_modules_exist = config_tools.user_module_exists(self.cfg, 'visual_stim', single_item_in_list=True)
         if visual_stim_modules_exist is not False: # 'visual_stim' is specified under module_paths in the cfg file
-            visual_stim_module_paths = config_tools.get_paths_to_module(self.cfg, 'visual_stim', single_item_in_list=True)
+            visual_stim_module_paths = config_tools.get_full_paths_to_module(self.cfg, 'visual_stim', single_item_in_list=True)
             for exists, path in zip(visual_stim_modules_exist, visual_stim_module_paths):
                 if not exists:
                     warnings.warn(f"Visual stim module {path} does not exist.")

--- a/stimpack/experiment/client.py
+++ b/stimpack/experiment/client.py
@@ -81,10 +81,14 @@ class BaseClient():
         self.manager.target('visual').set_idle_background(0)
 
         # # # Import user-defined stimpack.visual_stim stimuli modules on server screens # # #
-        visual_stim_module_paths = self.server_options.get('visual_stim_module_paths', None)
-        if visual_stim_module_paths is None:
-            visual_stim_module_paths = []
-        [self.manager.target('visual').import_stim_module(dir) for dir in visual_stim_module_paths]
+        visual_stim_modules_exist = config_tools.user_module_exists(self.cfg, 'visual_stim', single_item_in_list=True)
+        if visual_stim_modules_exist is not False: # 'visual_stim' is specified under module_paths in the cfg file
+            visual_stim_module_paths = config_tools.get_paths_to_module(self.cfg, 'visual_stim', single_item_in_list=True)
+            for exists, path in zip(visual_stim_modules_exist, visual_stim_module_paths):
+                if not exists:
+                    warnings.warn(f"Visual stim module {path} does not exist.")
+                else:
+                    self.manager.target('visual').import_stim_module(path)
 
     def stop_run(self):
         self.stop = True

--- a/stimpack/experiment/gui.py
+++ b/stimpack/experiment/gui.py
@@ -66,13 +66,18 @@ class ExperimentGUI(QWidget):
             sys.exit()
 
         print('# # # Loading protocol, data and client modules # # #')
-        user_protocol_exists = config_tools.user_module_exists(self.cfg, 'protocol')
-        if config_tools.user_module_exists(self.cfg, 'protocol'):
-            protocol_module = config_tools.load_user_module(self.cfg, 'protocol')
+
+        # Load protocol module(s). Multiple user-specific protocol modules can be loaded.
+        user_protocol_exists = config_tools.user_module_exists(self.cfg, 'protocol', single_item_in_list=True)
+        if isinstance(user_protocol_exists, list) and (True in user_protocol_exists): # at least one user protocol exists
+            protocol_module_full_paths = config_tools.get_full_paths_to_module(self.cfg, 'protocol', single_item_in_list=True)
+            protocol_modules = [config_tools.load_user_module_from_path(fp, f'protocol_{i:02d}') for i,fp in enumerate(protocol_module_full_paths)]
         else:   # use the built-in
             print('!!! Using builtin {} module. To use user defined module, you must point to that module in your config file !!!'.format('protocol'))
             example_protocol_path = os.path.join(ROOT_DIR, 'experiment', 'example_protocol.py')
             protocol_module = config_tools.load_user_module_from_path(example_protocol_path, 'protocol')
+        
+        # start a protocol object
         self.protocol_object =  protocol.BaseProtocol(self.cfg)
         self.available_protocols =  [x for x in get_all_subclasses(protocol.BaseProtocol) if x.__name__ not in ['BaseProtocol', 'SharedPixMapProtocol']]
 

--- a/stimpack/experiment/util/config_tools.py
+++ b/stimpack/experiment/util/config_tools.py
@@ -177,12 +177,13 @@ def get_screen_center(cfg):
     return screen_center
 
 def get_server_options(cfg):
+    default_server_options = {'use_remote_server': False,
+                              'data_directory': None}
     if 'current_rig_name' in cfg:
-        server_options = cfg.get('rig_config').get(cfg.get('current_rig_name')).get('server_options', {'host': '0.0.0.0', 'port': 60629, 'use_server': False})
+        server_options = cfg.get('rig_config').get(cfg.get('current_rig_name')).get('server_options', default_server_options)
     else:
         print('No rig selected, using default server settings')
-        server_options = {'use_remote_server': False,
-                          'data_directory': None}
+        server_options = default_server_options
     return server_options
 
 def get_data_directory(cfg):


### PR DESCRIPTION
Instead of having visual_stim modules imported through absolute paths under each rig definition, we now define it through either relative or absolute paths under "module paths". 

E.g.

```
module_paths:  # relative to the labpack directory specified in stimpack.experiment's path_to_labpack.txt
  protocol: labpack/protocol/mc_protocol.py  # module for user protocol classes. Should include class name "BaseProtocol"
  data: labpack/data.py  # module for data class. Class name should be "Data"
  client: labpack/client.py  # module for client class. Class name should be "Client"
  daq: labpack/device/daq.py  # daq module
  visual_stim: # visual stim modules
    - labpack/visual_stim/clandinin
```
All labpack users need to adopt this new mechanism once this PR is accepted.